### PR TITLE
CI: add github action to deploy docs to gh-pages branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,19 @@
+name: Deploy docs
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install "mkdocs>=1.5,<2.0" "mkdocs-material>=9.0,<10.0" "mkdocstrings[python]"
+      - run: mkdocs gh-deploy --force


### PR DESCRIPTION
added CI for documentation, push into `main` branch will now deploy web pages in `gh-pages` branch